### PR TITLE
Add test to demonstrate key generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,11 @@ alter the model to integrate with bank systems.
 
 IMPORTANT
 =========
-Regenerate certificates before deploying this in a production environment.
-See `config/tls/README.md` for details.
+Regenerate certificates and keys before deploying this in a production environment.
+
+This [test](src/test/java/io/token/banksample/GenerateKeyTest.java) can be used to generate a new key pair for signing.
+
+For ssl certificates, see `config/tls/README.md` for details.
 
 Server
 =======

--- a/src/test/java/io/token/banksample/GenerateKeyTest.java
+++ b/src/test/java/io/token/banksample/GenerateKeyTest.java
@@ -1,0 +1,20 @@
+package io.token.banksample;
+
+import io.token.security.crypto.Crypto;
+import io.token.security.crypto.CryptoRegistry;
+import io.token.security.crypto.CryptoType;
+
+import java.security.KeyPair;
+
+import org.junit.Test;
+
+public class GenerateKeyTest {
+    @Test
+    public void generate() {
+        Crypto crypto = CryptoRegistry.getInstance().cryptoFor(CryptoType.EDDSA);
+        KeyPair keyPair = crypto.generateKeyPair();
+        System.out.println("crypto: " + crypto.getAlgorithm().toUpperCase());
+        System.out.println("private-key: " + crypto.serialize(keyPair.getPrivate()));
+        System.out.println("public-key: " + crypto.serialize(keyPair.getPublic()));
+    }
+}

--- a/src/test/java/io/token/banksample/GenerateKeyTest.java
+++ b/src/test/java/io/token/banksample/GenerateKeyTest.java
@@ -14,9 +14,11 @@ public class GenerateKeyTest {
         Crypto crypto = CryptoRegistry.getInstance().cryptoFor(CryptoType.EDDSA);
         KeyPair keyPair = crypto.generateKeyPair();
         System.out.println("crypto: " + crypto.getAlgorithm().toUpperCase());
-        System.out.println("private-key (Used for signing bank auth payloads):"
-                + crypto.serialize(keyPair.getPrivate()));
-        System.out.println("public-key (Give to Token so that Token can verify bank auth payloads):"
-                + crypto.serialize(keyPair.getPublic()));
+        System.out.println("private-key: "
+                + crypto.serialize(keyPair.getPrivate())
+                + " // Used for signing bank auth payloads");
+        System.out.println("public-key: "
+                + crypto.serialize(keyPair.getPublic())
+                + "  // Give to Token so that Token can verify bank auth payloads");
     }
 }

--- a/src/test/java/io/token/banksample/GenerateKeyTest.java
+++ b/src/test/java/io/token/banksample/GenerateKeyTest.java
@@ -14,7 +14,9 @@ public class GenerateKeyTest {
         Crypto crypto = CryptoRegistry.getInstance().cryptoFor(CryptoType.EDDSA);
         KeyPair keyPair = crypto.generateKeyPair();
         System.out.println("crypto: " + crypto.getAlgorithm().toUpperCase());
-        System.out.println("private-key: " + crypto.serialize(keyPair.getPrivate()));
-        System.out.println("public-key: " + crypto.serialize(keyPair.getPublic()));
+        System.out.println("private-key (Used for signing bank auth payloads):"
+                + crypto.serialize(keyPair.getPrivate()));
+        System.out.println("public-key (Give to Token so that Token can verify bank auth payloads):"
+                + crypto.serialize(keyPair.getPublic()));
     }
 }


### PR DESCRIPTION
Adding a test to the sample to demonstrate how to generate keys. EDDSA keys generation can be non-trivial for banks. We could link this to our documentation later if needed.